### PR TITLE
modified scikit-learn to install from conda-forge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM bentoml/model-server:0.11.0-py37
 MAINTAINER ersilia
 
+RUN conda install -c conda-forge scikit-learn=1.0.2
+
 RUN pip install rdkit==2022.9.5
 RUN pip install numpy==1.21.6
 RUN pip install pandas==1.1.5
@@ -9,7 +11,6 @@ RUN pip install tqdm==4.65
 RUN pip install typing-extensions==4.5.0
 RUN pip install typed-argument-parser==1.8.0
 RUN pip install tensorboardX==2.6
-RUN pip install scikit-learn==0.22
 RUN pip install hyperopt==0.2.7
 
 WORKDIR /repo


### PR DESCRIPTION
- Modified scikit-learn to install from conda-forge distribution to solve the issue of scikit-learn not installing on arm64. [wheel support for aarch64](https://github.com/scikit-learn/scikit-learn/issues/17800) |  [here](https://github.com/scikit-learn/scikit-learn/issues/19137)
- Model fetch and makes prediction successfully after changes
[eos74bo_log.txt](https://github.com/ersilia-os/eos74bo/files/11709735/eos74bo_log.txt)
[eos74bo_prediction.csv](https://github.com/ersilia-os/eos74bo/files/11709737/eos74bossoutput.csv)
